### PR TITLE
Error when compiled in QStack<bool> m_skipEndVisit;

### DIFF
--- a/languages/qmljs/libs/qmljs/qmljsdocument.h
+++ b/languages/qmljs/libs/qmljs/qmljsdocument.h
@@ -31,8 +31,9 @@
 #define QMLJSDOCUMENT_H
 
 #include <QList>
-#include <QSharedPointer>
+#include <QStack>
 #include <QString>
+#include <QSharedPointer>
 
 #include <languageutils/fakemetaobject.h>
 


### PR DESCRIPTION
(languages/qmljs/duchain/declarationbuilder.h)

QStack was not added before use.

Signed-off-by: Patrick J.P <patrickelectric@gmail.com>