### PR TITLE
Add exception specification to function signatures

### DIFF
--- a/plugins/clang/util/clangutils.cpp
+++ b/plugins/clang/util/clangutils.cpp
@@ -321,6 +321,15 @@ QString ClangUtils::getCursorSignature(CXCursor cursor, const QString& scope, co
         stream << " const";
     }
 
+    switch (clang_getCursorExceptionSpecificationType(cursor)) {
+        case CXCursor_ExceptionSpecificationKind_DynamicNone:
+            stream << " throw()";
+            break;
+        case CXCursor_ExceptionSpecificationKind_BasicNoexcept:
+            stream << " noexcept";
+            break;
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
This fix adds exception specifications to function signatures if the specification is `noexcept` (no expression provided) or `throw()` (no types provided). Partially fixes bug https://bugs.kde.org/show_bug.cgi?id=188180.